### PR TITLE
Nice improvements

### DIFF
--- a/ttax/autodiff.py
+++ b/ttax/autodiff.py
@@ -120,8 +120,7 @@ def hessian_vector_product(func: Callable[[TTTensOrMat], float]) -> Callable[[TT
         x_projection = riemannian.deltas_to_tangent(deltas_inner, x)
         return func(x_projection)
 
-      function_value, cores_grad = jax.value_and_grad(augmented_inner_func,
-                                                      deltas_outer)
+      function_value, cores_grad = jax.value_and_grad(augmented_inner_func)(deltas_outer)
       # TODO: support runtime checks
 
       vector_projected = project(vector, x)
@@ -129,7 +128,7 @@ def hessian_vector_product(func: Callable[[TTTensOrMat], float]) -> Callable[[TT
       products = [jnp.sum(a * b) for a, b in zip(cores_grad, vec_deltas)]
       return sum(products)
 
-    _, second_cores_grad = jax.value_and_grad(augmented_outer_func, deltas)
+    _, second_cores_grad = jax.value_and_grad(augmented_outer_func)(deltas)
     final_deltas = _enforce_gauge_conditions(second_cores_grad, left)
     # TODO: pass left and right?
     return riemannian.deltas_to_tangent(final_deltas, x)

--- a/ttax/autodiff.py
+++ b/ttax/autodiff.py
@@ -124,8 +124,8 @@ def hessian_vector_product(func: Callable[[TTTensOrMat], float]) -> Callable[[TT
                                                       deltas_outer)
       # TODO: support runtime checks
 
-      vector_projected = riemannian.project(vector, x)
-      vec_deltas = riemannian.tangent_space_to_deltas(vector_projected)
+      vector_projected = project(vector, x)
+      vec_deltas = riemannian.tangent_to_deltas(vector_projected)
       products = [jnp.sum(a * b) for a, b in zip(cores_grad, vec_deltas)]
       return sum(products)
 

--- a/ttax/autodiff_test.py
+++ b/ttax/autodiff_test.py
@@ -44,5 +44,22 @@ class AutodiffTest(jtu.JaxTestCase):
     double_project = autodiff.project(project, vector)
     self.assertAllClose(ops.full(project), ops.full(double_project), rtol=1e-4)
 
+  def testHessianVectorProduct(self):
+      rng1, rng2, rng3 = jax.random.split(jax.random.PRNGKey(0), 3)
+      dtype = jnp.float32
+      shape = (5, 5, 5)
+      A = random_.matrix(rng1, (shape, shape), dtype=dtype)
+      AT = ops.transpose(A)
+      A_plus_AT = A + AT
+      x = random_.tensor(rng2, shape, dtype=dtype)
+      vec = random_.tensor(rng3, shape, dtype=dtype)
+      proj_vec = autodiff.project(vec, x)
+
+      func = lambda x: ops.flat_inner(x, ops.matrix_tensor_matmul(A, x))
+      desired = autodiff.project(ops.matrix_tensor_matmul(A_plus_AT, proj_vec), x)
+      desired = ops.full(desired)
+      actual = ops.full(autodiff.hessian_vector_product(func)(x, vec))
+      self.assertAllClose(desired, actual, rtol=1e-4)
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/ttax/autodiff_test.py
+++ b/ttax/autodiff_test.py
@@ -51,12 +51,12 @@ class AutodiffTest(jtu.JaxTestCase):
       A = random_.matrix(rng1, (shape, shape), dtype=dtype)
       AT = ops.transpose(A)
       A_plus_AT = A + AT
-      x = random_.tensor(rng2, shape, dtype=dtype)
-      vec = random_.tensor(rng3, shape, dtype=dtype)
+      x = random_.matrix(rng2, (shape, None), dtype=dtype)
+      vec = random_.matrix(rng3, (shape, None), dtype=dtype)
       proj_vec = autodiff.project(vec, x)
 
-      func = lambda x: ops.flat_inner(x, ops.tt_matvec(A, x))
-      desired = autodiff.project(ops.tt_matvec(A_plus_AT, proj_vec), x)
+      func = lambda x: ops.flat_inner(x, A @ x)
+      desired = autodiff.project(A_plus_AT @ proj_vec, x)
       desired = ops.full(desired)
       actual = ops.full(autodiff.hessian_vector_product(func)(x, vec))
       self.assertAllClose(desired, actual, rtol=1e-4)

--- a/ttax/autodiff_test.py
+++ b/ttax/autodiff_test.py
@@ -55,8 +55,8 @@ class AutodiffTest(jtu.JaxTestCase):
       vec = random_.tensor(rng3, shape, dtype=dtype)
       proj_vec = autodiff.project(vec, x)
 
-      func = lambda x: ops.flat_inner(x, ops.matrix_tensor_matmul(A, x))
-      desired = autodiff.project(ops.matrix_tensor_matmul(A_plus_AT, proj_vec), x)
+      func = lambda x: ops.flat_inner(x, ops.tt_matvec(A, x))
+      desired = autodiff.project(ops.tt_matvec(A_plus_AT, proj_vec), x)
       desired = ops.full(desired)
       actual = ops.full(autodiff.hessian_vector_product(func)(x, vec))
       self.assertAllClose(desired, actual, rtol=1e-4)

--- a/ttax/base_class.py
+++ b/ttax/base_class.py
@@ -23,6 +23,16 @@ class TTBase:
     from ttax import ops
     return ops.add(self, other)
 
+  def __neg__(self):
+    # We can't import ops in the beginning since it creates cyclic dependencies.
+    from ttax import ops
+    return ops.multiply(self, -1)
+
+  def __sub__(self, other):
+    # We can't import ops in the beginning since it creates cyclic dependencies.
+    from ttax import ops
+    return ops.sub(self, other)
+
   def __rmul__(self, other):
     # We can't import ops in the beginning since it creates cyclic dependencies.
     from ttax import ops

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -282,6 +282,21 @@ def _add_matrix_cores(tt_a, tt_b):
   return tt_cores
 
 
+def sub(tt_a, tt_b):
+  """Returns a `TT-object` corresponding to elementwise subtraction `tt_a - tt_b`.
+    The shapes of `tt_a` and `tt_b` should coincide.
+
+    :type tt_a: `TT-Tensor` or `TT-Matrix`
+    :param tt_a: first argument
+    :type tt_b: `TT-Tensor` or `TT-Matrix`
+    :param tt_b: second argument
+    :rtype: `TT-Tensor` or `TT-Matrix`
+    :return: `tt_a - tt_b`
+    :raises [ValueError]: if the arguments shapes do not coincide
+    """
+  return add(tt_a, multiply(tt_b, -1))
+
+
 def are_shapes_equal(tt_a, tt_b):
   """Returns the result of equality check of 2 tensors' shapes: 
   `True` if shapes are equal and `False` otherwise.

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -385,6 +385,7 @@ def _mul_by_scalar(tt, c):
     return TT(cores)
 
 
+@tt_vmap()
 def transpose(tt):
   """Transpose a TT-matrix or a batch of TT-matrices.
 
@@ -397,14 +398,7 @@ def transpose(tt):
   if not isinstance(tt, TTMatrix) or not tt.is_tt_matrix:
     raise ValueError('The argument should be a TT-matrix.')
 
-  if tt.num_batch_dims == 0:
-    transposed_tt_cores = [
-      jnp.transpose(tt.tt_cores[core_idx], (0, 2, 1, 3)) for core_idx in range(tt.ndim)
-    ]
-  else:
-    # Batch of TT-matrices
-    transposed_tt_cores = [
-      jnp.transpose(tt.tt_cores[core_idx], (0, 1, 3, 2, 4)) for core_idx in range(tt.ndim)
-    ]
-
+  transposed_tt_cores = [
+    jnp.transpose(tt.tt_cores[core_idx], (0, 2, 1, 3)) for core_idx in range(tt.ndim)
+  ]
   return TTMatrix(transposed_tt_cores)

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -167,6 +167,30 @@ def flat_inner(a, b):
   return res
 
 
+def matrix_tensor_matmul(A, x):
+  """Returns matrix multiplication of given TT-matrix and TT-tensor
+  if A: R^{n1 x ... nd} --> R^{m1 x ... md} — tensor operator, and x \in R^{n1 x ... nd},
+  then matrix_tensor_matmul returns A(x) \in R^{m1 x ... md}.
+  Corresponding modes of A and x should coincide.
+
+      :type A:  `TT-Matrix`
+      :param A: `TT-Matrix` represents a tensor operator
+      :type x:  `TT`
+      :param x: `TT-Tensor`
+      :rerurn:  `TT-Tensor` A(x) is target space of operator A
+      :rtype:   `TT-Tensor`
+      :raises [ValueError]: if the arguments corresponding modes do not coincide
+    """
+
+  tt_einsum = TTEinsum(
+    inputs=[['a', 'ij', 'b'], ['c', 'j', 'd']],
+    output=['ac', 'i', 'bd'],
+    how_to_apply='independent'
+  )
+  func = to_function(tt_einsum)
+  return TT(unwrap_tt(func(A, x)).tt_cores)
+
+
 def matmul(a, b):
   """Calculate matrix multiplication of given `TT-Matrices` wrapped with `WrappedTT`.
   

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -383,3 +383,22 @@ def _mul_by_scalar(tt, c):
     return TTMatrix(cores)
   else:
     return TT(cores)
+
+
+def transpose(tt):
+  """Transpose a TT-matrix or a batch of TT-matrices.
+
+  :type tt:   `TT-Matrix` object containing TT-matrix
+  :param tt:  TT-matrix
+  :return:    `TT-Matrix` object containing TT-matrix
+  :rtype:     `TT-Matrix` object containing TT-matrix
+  :raises [ValueError]: if the argument is not a TT-matrix
+  """
+  if not isinstance(tt, TTMatrix) or not tt.is_tt_matrix:
+    raise ValueError('The argument should be a TT-matrix.')
+
+  transposed_tt_cores = [
+    jnp.transpose(tt.tt_cores[core_idx], (0, 2, 1, 3)) for core_idx in range(tt.ndim)
+  ]
+
+  return TT(transposed_tt_cores)

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -167,30 +167,6 @@ def flat_inner(a, b):
   return res
 
 
-def tt_matvec(A, x):
-  """Returns matvec multiplication of given TT-matrix and TT-tensor
-  if A: R^{n1 x ... nd} --> R^{m1 x ... md} — tensor operator, and x \in R^{n1 x ... nd},
-  then tt_matvec returns A(x) \in R^{m1 x ... md}.
-  Corresponding modes of A and x should coincide.
-
-      :type A:  `TT-Matrix`
-      :param A: `TT-Matrix` represents a tensor operator
-      :type x:  `TT`
-      :param x: `TT-Tensor`
-      :rerurn:  `TT-Tensor` A(x) is target space of operator A
-      :rtype:   `TT-Tensor`
-      :raises [ValueError]: if the arguments corresponding modes do not coincide
-    """
-
-  tt_einsum = TTEinsum(
-    inputs=[['a', 'ij', 'b'], ['c', 'j', 'd']],
-    output=['ac', 'i', 'bd'],
-    how_to_apply='independent'
-  )
-  func = to_function(tt_einsum)
-  return TT(unwrap_tt(func(A, x)).tt_cores)
-
-
 def matmul(a, b):
   """Calculate matrix multiplication of given `TT-Matrices` wrapped with `WrappedTT`.
   

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -388,17 +388,23 @@ def _mul_by_scalar(tt, c):
 def transpose(tt):
   """Transpose a TT-matrix or a batch of TT-matrices.
 
-  :type tt:   `TT-Matrix` object containing TT-matrix
-  :param tt:  TT-matrix
-  :return:    `TT-Matrix` object containing TT-matrix
-  :rtype:     `TT-Matrix` object containing TT-matrix
+  :type tt:   `TT-Matrix` object containing TT-matrix or batch of TT-matrices
+  :param tt:  TT-matrix or batch of TT-matrices
+  :return:    `TT-Matrix` object containing TT-matrix or batch of TT-matrices
+  :rtype:     `TT-Matrix` object containing TT-matrix or batch of TT-matrices
   :raises [ValueError]: if the argument is not a TT-matrix
   """
   if not isinstance(tt, TTMatrix) or not tt.is_tt_matrix:
     raise ValueError('The argument should be a TT-matrix.')
 
-  transposed_tt_cores = [
-    jnp.transpose(tt.tt_cores[core_idx], (0, 2, 1, 3)) for core_idx in range(tt.ndim)
-  ]
+  if tt.num_batch_dims == 0:
+    transposed_tt_cores = [
+      jnp.transpose(tt.tt_cores[core_idx], (0, 2, 1, 3)) for core_idx in range(tt.ndim)
+    ]
+  else:
+    # Batch of TT-matrices
+    transposed_tt_cores = [
+      jnp.transpose(tt.tt_cores[core_idx], (0, 1, 3, 2, 4)) for core_idx in range(tt.ndim)
+    ]
 
-  return TT(transposed_tt_cores)
+  return TTMatrix(transposed_tt_cores)

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -422,14 +422,14 @@ def transpose(tt):
   return TTMatrix(transposed_tt_cores)
 
 
-def vec_to_mat(tt, by_columns=True):
+def tensor_to_vector(tt, vertical=True):
   """Converts TT-tensor to TT-matrix with column shape equals to I = (1, ..., 1). If by_columns is False,
   then row shape equals to I.
 
     :type tt:         `TT`
     :param tt:        TT-tensor
-    :type by_columns: `bool`
-    :param by_columns: defines, whether tt will be located by columns or by rows
+    :type vertical: `bool`
+    :param vertical: defines, whether tt will be located by columns or by rows
     :return:          `TT-Matrix`
     :rtype:           `TT-Matrix`
     :raises [ValueError]: if the argument is not a TT-tensor
@@ -439,7 +439,7 @@ def vec_to_mat(tt, by_columns=True):
 
   cores = []
   for core in tt.tt_cores:
-    if by_columns:
+    if vertical:
       cores.append(jnp.reshape(core, (core.shape[0], core.shape[1], 1, core.shape[2]), order="F"))
     else:
       cores.append(jnp.reshape(core, (core.shape[0], 1, core.shape[1], core.shape[2]), order="F"))
@@ -447,7 +447,7 @@ def vec_to_mat(tt, by_columns=True):
 
 
 
-def mat_to_vec(tt):
+def vector_to_tensor(tt):
   """Converts TT-matrix to TT-tensor, if matrix has shape N x 1 or 1 x N
 
     :type tt:   `TT-Matrix`

--- a/ttax/ops.py
+++ b/ttax/ops.py
@@ -167,10 +167,10 @@ def flat_inner(a, b):
   return res
 
 
-def matrix_tensor_matmul(A, x):
-  """Returns matrix multiplication of given TT-matrix and TT-tensor
+def tt_matvec(A, x):
+  """Returns matvec multiplication of given TT-matrix and TT-tensor
   if A: R^{n1 x ... nd} --> R^{m1 x ... md} — tensor operator, and x \in R^{n1 x ... nd},
-  then matrix_tensor_matmul returns A(x) \in R^{m1 x ... md}.
+  then tt_matvec returns A(x) \in R^{m1 x ... md}.
   Corresponding modes of A and x should coincide.
 
       :type A:  `TT-Matrix`

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -275,6 +275,23 @@ class TTMatrixTest(jtu.JaxTestCase):
     self.assertAllClose(res_actual1, res_desired, rtol=1e-5)
     self.assertAllClose(res_actual2, res_desired, rtol=1e-5)
 
+  def testSub(self):
+    # Subtract two TT-matrices.
+    rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))
+    dtype = jnp.float32
+    left_shape = (2, 3, 4)
+    right_shape = (4, 4, 4)
+    tt_a = random_.matrix(rng1, (left_shape, right_shape), tt_rank=3,
+                          dtype=dtype)
+    tt_b = random_.matrix(rng2, (left_shape, right_shape), tt_rank=[1, 4, 3, 1],
+                          dtype=dtype)
+
+    res_actual1 = ops.full(ops.sub(tt_a, tt_b))
+    res_actual2 = ops.full(tt_a - tt_b)
+    res_desired = ops.full(tt_a) - ops.full(tt_b)
+    self.assertAllClose(res_actual1, res_desired, rtol=1e-5)
+    self.assertAllClose(res_actual2, res_desired, rtol=1e-5)
+
   def testAddSameBatchSize(self):
     # Add two batches of TT-matrices.
     rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -226,6 +226,18 @@ class TTMatrixTest(jtu.JaxTestCase):
     self.assertAllClose(res_actual1, res_desired, rtol=1e-4)
     self.assertAllClose(res_actual2, res_desired, rtol=1e-4)
 
+  def testMatrixTensorMatmul(self):
+    rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))
+    dtype = jnp.float32
+    N_shape = (2, 3, 4)
+    M_shape = (4, 4, 4)
+    tt_operator = random_.matrix(rng1, (M_shape, N_shape), tt_rank=3,
+                          dtype=dtype)
+    tt_tensor = random_.tensor(rng2, N_shape, tt_rank=[1, 4, 3, 1],
+                          dtype=dtype)
+    target_shape = ops.matrix_tensor_matmul(tt_operator, tt_tensor).shape
+    self.assertEqual(M_shape, target_shape)
+
   def testMultiplyBatch(self):
     # Elementwise multiply two batches of TT-matrices.
     rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -235,7 +235,7 @@ class TTMatrixTest(jtu.JaxTestCase):
                           dtype=dtype)
     tt_tensor = random_.tensor(rng2, N_shape, tt_rank=[1, 4, 3, 1],
                           dtype=dtype)
-    target_shape = ops.matrix_tensor_matmul(tt_operator, tt_tensor).shape
+    target_shape = ops.tt_matvec(tt_operator, tt_tensor).shape
     self.assertEqual(M_shape, target_shape)
 
   def testMultiplyBatch(self):

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -369,19 +369,19 @@ class TTMatrixTest(jtu.JaxTestCase):
 
   def testMatVecConvertion(self):
     # Take common vector, convert it into matrices (by columns and by rows) and then convert it back to vector
-    #                            ---> Matrix 1 (N x 1) ---
+    #                            ---> Vector 1 (N x 1) ---
     #                         /                             \
-    # Common vector (N,) ---                                   ---> back to Common vector (N,)
+    # Common tensor (N,) ---                                   ---> back to Common tensor (N,)
     #                         \                             /
-    #                            ---> Matrix 2 (1 x N) ---
+    #                            ---> Vector 2 (1 x N) ---
     rng = jax.random.PRNGKey(0)
     shape = (5, 5, 5, 5)
-    common_vec = random_.tensor(rng, shape)
-    mat1 = ops.vec_to_mat(common_vec)
-    mat2 = ops.vec_to_mat(common_vec, False)
-    self.assertAllClose(ops.full(ops.mat_to_vec(mat1)), ops.full(ops.mat_to_vec(mat2)))
-    self.assertAllClose(ops.full(ops.mat_to_vec(mat1)), ops.full(common_vec))
-    self.assertAllClose(ops.full(ops.mat_to_vec(mat2)), ops.full(common_vec))
+    common_tensor = random_.tensor(rng, shape)
+    vec1 = ops.tensor_to_vector(common_tensor)
+    vec2 = ops.tensor_to_vector(common_tensor, False)
+    self.assertAllClose(ops.full(ops.vector_to_tensor(vec1)), ops.full(ops.vector_to_tensor(vec2)))
+    self.assertAllClose(ops.full(ops.vector_to_tensor(vec1)), ops.full(common_tensor))
+    self.assertAllClose(ops.full(ops.vector_to_tensor(vec2)), ops.full(common_tensor))
 
 
 if __name__ == '__main__':

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -92,6 +92,20 @@ class TTTensorTest(jtu.JaxTestCase):
     self.assertAllClose(res_actual1, res_desired)
     self.assertAllClose(res_actual2, res_desired)
 
+  def testSub(self):
+    # Subtract two TT-tensors.
+    rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))
+    dtype = jnp.float32
+    tt_a = random_.tensor(rng1, (2, 1, 3, 4), tt_rank=2, dtype=dtype)
+    tt_b = random_.tensor(rng2, (2, 1, 3, 4), tt_rank=[1, 2, 4, 3, 1],
+                          dtype=dtype)
+
+    res_actual1 = ops.full(ops.sub(tt_a, tt_b))
+    res_actual2 = ops.full(tt_a - tt_b)
+    res_desired = ops.full(tt_a) - ops.full(tt_b)
+    self.assertAllClose(res_actual1, res_desired)
+    self.assertAllClose(res_actual2, res_desired)
+
   def testAddSameBatchSize(self):
     # Add two batches of TT-tensors.
     rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -226,18 +226,6 @@ class TTMatrixTest(jtu.JaxTestCase):
     self.assertAllClose(res_actual1, res_desired, rtol=1e-4)
     self.assertAllClose(res_actual2, res_desired, rtol=1e-4)
 
-  def testMatrixTensorMatmul(self):
-    rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))
-    dtype = jnp.float32
-    N_shape = (2, 3, 4)
-    M_shape = (4, 4, 4)
-    tt_operator = random_.matrix(rng1, (M_shape, N_shape), tt_rank=3,
-                          dtype=dtype)
-    tt_tensor = random_.tensor(rng2, N_shape, tt_rank=[1, 4, 3, 1],
-                          dtype=dtype)
-    target_shape = ops.tt_matvec(tt_operator, tt_tensor).shape
-    self.assertEqual(M_shape, target_shape)
-
   def testMultiplyBatch(self):
     # Elementwise multiply two batches of TT-matrices.
     rng1, rng2 = jax.random.split(jax.random.PRNGKey(0))

--- a/ttax/ops_test.py
+++ b/ttax/ops_test.py
@@ -358,7 +358,24 @@ class TTMatrixTest(jtu.JaxTestCase):
     res_desired = c * ops.full(tt)
     self.assertAllClose(res_actual1, res_desired, rtol=1e-4) 
     self.assertAllClose(res_actual2, res_desired, rtol=1e-4)  
-    self.assertAllClose(res_actual3, res_desired, rtol=1e-4)  
+    self.assertAllClose(res_actual3, res_desired, rtol=1e-4)
+
+
+  def testMatVecConvertion(self):
+    # Take common vector, convert it into matrices (by columns and by rows) and then convert it back to vector
+    #                            ---> Matrix 1 (N x 1) ---
+    #                         /                             \
+    # Common vector (N,) ---                                   ---> back to Common vector (N,)
+    #                         \                             /
+    #                            ---> Matrix 2 (1 x N) ---
+    rng = jax.random.PRNGKey(0)
+    shape = (5, 5, 5, 5)
+    common_vec = random_.tensor(rng, shape)
+    mat1 = ops.vec_to_mat(common_vec)
+    mat2 = ops.vec_to_mat(common_vec, False)
+    self.assertAllClose(ops.full(ops.mat_to_vec(mat1)), ops.full(ops.mat_to_vec(mat2)))
+    self.assertAllClose(ops.full(ops.mat_to_vec(mat1)), ops.full(common_vec))
+    self.assertAllClose(ops.full(ops.mat_to_vec(mat2)), ops.full(common_vec))
 
 
 if __name__ == '__main__':

--- a/ttax/random_.py
+++ b/ttax/random_.py
@@ -49,18 +49,31 @@ def matrix(rng, shape, tt_rank=2, batch_shape=None, dtype=jnp.float32):
     
   :param rng: JAX PRNG key
   :type rng: random state is described by two unsigned 32-bit integers
-  :param shape: desired tensor shape
-  :type shape: array
+  :param shape: desired tensor shape. Also supports omitting one of the dimensions
+        matrix(..., shape=((2, 2, 2), None))
+      and
+        matrix(..., shape=(None, (2, 2, 2)))
+      will create an 8-element column/row vector.
+  :type shape: tuple
   :param tt_rank: desired `TT-ranks` of `TT-Matrix`
   :type tt_rank: single number for equal `TT-ranks` or array specifying all `TT-ranks`
   :param batch_shape: desired batch shape of `TT-Matrix`
-  :type batch_shape: array
+  :type batch_shape: tuple
   :param dtype: type of elements in `TT-Matrix`
   :type dtype: `dtype`
   :return: generated `TT-Matrix`
   :rtype: TTMatrix
+  :raises [ValueError]: if shape is (None, None)
   """
-  shape = [np.array(shape[0]), np.array(shape[1])]
+  if shape == (None, None):
+    raise ValueError("At least one of shape elements must not be None")
+  if None in shape:
+    shape = [
+      np.array(shape[0]) if shape[0] is not None else np.ones(len(shape[1]), dtype=int),
+      np.array(shape[1]) if shape[1] is not None else np.ones(len(shape[0]), dtype=int),
+    ]
+  else:
+    shape = [np.array(shape[0]), np.array(shape[1])]
   tt_rank = np.array(tt_rank)
   batch_shape = list(batch_shape) if batch_shape else []
 


### PR DESCRIPTION
I fixed some inaccuracies in hessian-vector-product and added test from description.
Then I implemented such operations as TT-Matrix transpose (supports batched) and matrix-tensor-matmul, which allows apply TT-Matrix to arbitrary tensor as tensor operator.

Finally I added __neg__ and __sub__ methods to class TTBase, cause for instance in Riemann gradient descent it is not convenient to write 
`riemann_grad = (-1) * grad(x)`
instead of
`riemann_grad = -grad(x)`